### PR TITLE
Add AI agent discoverability: WebMCP, backend MCP server, and SEO

### DIFF
--- a/api/mcp.js
+++ b/api/mcp.js
@@ -1,0 +1,378 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { z } from "zod";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Load restaurant data at cold start
+let allRestaurants;
+try {
+  const dataPath = join(process.cwd(), "public", "data", "restaurants.json");
+  allRestaurants = JSON.parse(readFileSync(dataPath, "utf-8"));
+} catch {
+  allRestaurants = [];
+}
+
+const PROGRAMS = [
+  {
+    id: "chase_sapphire",
+    name: "Chase Sapphire Reserve",
+    description: "Premium dining benefits through OpenTable partnership",
+    card_required: "Chase Sapphire Reserve",
+    benefit_description: "Dining credits at participating OpenTable restaurants. Credits work even as walk-ins without advance reservations.",
+    dataKey: "chase",
+  },
+  {
+    id: "amex_gda",
+    name: "Amex Global Dining Access",
+    description: "Global Dining Access by Resy for American Express Platinum and Centurion cardholders",
+    card_required: "Amex Platinum / Centurion",
+    benefit_description: "Dining credits at participating Resy restaurants. Credits work even as walk-ins without advance reservations.",
+    dataKey: "amex",
+  },
+];
+
+function programIdToDataKey(programId) {
+  const prog = PROGRAMS.find((p) => p.id === programId);
+  return prog ? prog.dataKey : programId;
+}
+
+function haversineDistance(lat1, lon1, lat2, lon2) {
+  const R = 3959; // Earth radius in miles
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+function buildRefUrl(baseUrl) {
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set("ref", "ReserveMap");
+    return url.toString();
+  } catch {
+    return baseUrl;
+  }
+}
+
+function formatRestaurant(r) {
+  return {
+    name: r.name,
+    program: r.program === "chase" ? "chase_sapphire" : "amex_gda",
+    city: r.city || null,
+    state: r.state || null,
+    address: r.address || null,
+    cuisine: r.cuisine || null,
+    neighborhood: r.neighborhood || null,
+    website: r.website || null,
+    reservation_url: buildRefUrl(r.bookingUrl),
+    coordinates: { lat: r.lat, lon: r.lon },
+  };
+}
+
+function createServer() {
+  const server = new McpServer({
+    name: "ReserveMap",
+    version: "1.0.0",
+  });
+
+  // 1. search_restaurants
+  server.tool(
+    "search_restaurants",
+    "Search for restaurants participating in premium credit card dining programs (Chase Sapphire Reserve, Amex Global Dining Access). Supports filtering by program, city, state, and text query. Credits work even as walk-ins.",
+    {
+      query: z.string().optional().describe("Search term (restaurant name, cuisine, neighborhood)"),
+      program: z.enum(["chase_sapphire", "amex_gda"]).optional().describe("Filter by credit card dining program"),
+      city: z.string().optional().describe("Filter by city name"),
+      state: z.string().optional().describe("Filter by US state (2-letter code)"),
+      limit: z.number().optional().describe("Max results to return (default 20)"),
+    },
+    async (args) => {
+      let results = [...allRestaurants];
+      if (args.query) {
+        const q = args.query.toLowerCase();
+        results = results.filter(
+          (r) =>
+            r.name.toLowerCase().includes(q) ||
+            (r.city && r.city.toLowerCase().includes(q)) ||
+            (r.cuisine && r.cuisine.toLowerCase().includes(q)) ||
+            (r.neighborhood && r.neighborhood.toLowerCase().includes(q))
+        );
+      }
+      if (args.program) {
+        const dataKey = programIdToDataKey(args.program);
+        results = results.filter((r) => r.program === dataKey);
+      }
+      if (args.city) results = results.filter((r) => r.city && r.city.toLowerCase() === args.city.toLowerCase());
+      if (args.state) results = results.filter((r) => r.state && r.state.toLowerCase() === args.state.toLowerCase());
+
+      const limited = results.slice(0, args.limit || 20);
+      return {
+        content: [{ type: "text", text: JSON.stringify(limited.map(formatRestaurant), null, 2) }],
+      };
+    }
+  );
+
+  // 2. get_restaurant_details
+  server.tool(
+    "get_restaurant_details",
+    "Get full details for a specific restaurant including all dining programs it participates in, address, coordinates, website, and reservation links.",
+    {
+      name: z.string().describe("Restaurant name to look up"),
+      city: z.string().optional().describe("City to disambiguate if multiple matches"),
+    },
+    async (args) => {
+      const q = args.name.toLowerCase();
+      let matches = allRestaurants.filter((r) => r.name.toLowerCase() === q);
+      if (matches.length === 0) {
+        matches = allRestaurants.filter((r) => r.name.toLowerCase().includes(q));
+      }
+      if (args.city) {
+        const cityQ = args.city.toLowerCase();
+        const cityFiltered = matches.filter((r) => r.city && r.city.toLowerCase() === cityQ);
+        if (cityFiltered.length > 0) matches = cityFiltered;
+      }
+      if (matches.length === 0) {
+        return { content: [{ type: "text", text: "No restaurant found matching that name." }] };
+      }
+      return {
+        content: [{ type: "text", text: JSON.stringify(matches.map(formatRestaurant), null, 2) }],
+      };
+    }
+  );
+
+  // 3. list_programs
+  server.tool(
+    "list_programs",
+    "List all available premium credit card dining programs with descriptions, card requirements, and restaurant counts.",
+    {},
+    async () => {
+      const programsWithCounts = PROGRAMS.map((p) => ({
+        id: p.id,
+        name: p.name,
+        description: p.description,
+        card_required: p.card_required,
+        benefit_description: p.benefit_description,
+        restaurant_count: allRestaurants.filter((r) => r.program === p.dataKey).length,
+      }));
+      return {
+        content: [{ type: "text", text: JSON.stringify(programsWithCounts, null, 2) }],
+      };
+    }
+  );
+
+  // 4. get_restaurants_near_location
+  server.tool(
+    "get_restaurants_near_location",
+    "Find restaurants near a geographic coordinate. Returns restaurants sorted by distance. Useful for finding nearby dining credit opportunities.",
+    {
+      lat: z.number().describe("Latitude"),
+      lon: z.number().describe("Longitude"),
+      radius_miles: z.number().optional().describe("Search radius in miles (default 5)"),
+      program: z.enum(["chase_sapphire", "amex_gda"]).optional().describe("Filter by program"),
+      limit: z.number().optional().describe("Max results (default 20)"),
+    },
+    async (args) => {
+      const radius = args.radius_miles || 5;
+      let candidates = [...allRestaurants];
+      if (args.program) {
+        const dataKey = programIdToDataKey(args.program);
+        candidates = candidates.filter((r) => r.program === dataKey);
+      }
+      const withDistance = candidates
+        .map((r) => ({ ...r, distance_miles: haversineDistance(args.lat, args.lon, r.lat, r.lon) }))
+        .filter((r) => r.distance_miles <= radius)
+        .sort((a, b) => a.distance_miles - b.distance_miles);
+
+      const limited = withDistance.slice(0, args.limit || 20);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              limited.map((r) => ({
+                ...formatRestaurant(r),
+                distance_miles: Math.round(r.distance_miles * 100) / 100,
+              })),
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+
+  // 5. get_program_cities
+  server.tool(
+    "get_program_cities",
+    "List all cities that have restaurants for a given dining program, with restaurant counts per city.",
+    {
+      program: z.enum(["chase_sapphire", "amex_gda"]).describe("Program to list cities for"),
+    },
+    async (args) => {
+      const dataKey = programIdToDataKey(args.program);
+      const programRestaurants = allRestaurants.filter((r) => r.program === dataKey);
+      const cityMap = {};
+      for (const r of programRestaurants) {
+        if (!r.city) continue;
+        const key = `${r.city}|${r.state || ""}`;
+        if (!cityMap[key]) cityMap[key] = { city: r.city, state: r.state || null, count: 0 };
+        cityMap[key].count++;
+      }
+      const cities = Object.values(cityMap).sort((a, b) => b.count - a.count);
+      return {
+        content: [{ type: "text", text: JSON.stringify(cities, null, 2) }],
+      };
+    }
+  );
+
+  // 6. navigate_to_restaurant (returns deep link)
+  server.tool(
+    "navigate_to_restaurant",
+    "Get a deep link URL to view a specific restaurant on the ReserveMap interactive map. Opens the map centered on the restaurant.",
+    {
+      name: z.string().describe("Restaurant name"),
+      city: z.string().optional().describe("City to disambiguate"),
+    },
+    async (args) => {
+      const q = args.name.toLowerCase();
+      let matches = allRestaurants.filter((r) => r.name.toLowerCase().includes(q));
+      if (args.city) {
+        const cityQ = args.city.toLowerCase();
+        const cityFiltered = matches.filter((r) => r.city && r.city.toLowerCase() === cityQ);
+        if (cityFiltered.length > 0) matches = cityFiltered;
+      }
+      if (matches.length === 0) {
+        return { content: [{ type: "text", text: "No restaurant found matching that name." }] };
+      }
+      const r = matches[0];
+      const deepLink = `https://reservemap.vercel.app/?restaurant=${encodeURIComponent(r.name)}&lat=${r.lat}&lon=${r.lon}`;
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ ...formatRestaurant(r), map_url: deepLink }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // 7. filter_map_by_program (returns deep link)
+  server.tool(
+    "filter_map_by_program",
+    "Get a deep link URL to view the ReserveMap filtered by a specific dining program.",
+    {
+      program: z.enum(["chase_sapphire", "amex_gda", "all"]).describe("Program to filter by, or 'all' to show everything"),
+    },
+    async (args) => {
+      const deepLink = `https://reservemap.vercel.app/?program=${args.program}`;
+      const dataKey = args.program === "all" ? null : programIdToDataKey(args.program);
+      const count = dataKey ? allRestaurants.filter((r) => r.program === dataKey).length : allRestaurants.length;
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify({ map_url: deepLink, restaurant_count: count, program: args.program }, null, 2),
+          },
+        ],
+      };
+    }
+  );
+
+  // 8. open_reservation
+  server.tool(
+    "open_reservation",
+    "Get a reservation link for a restaurant on OpenTable or Resy with referral tracking. Returns the URL — the user can open it in their browser.",
+    {
+      name: z.string().describe("Restaurant name"),
+      city: z.string().optional().describe("City to disambiguate"),
+    },
+    async (args) => {
+      const q = args.name.toLowerCase();
+      let matches = allRestaurants.filter((r) => r.name.toLowerCase().includes(q));
+      if (args.city) {
+        const cityQ = args.city.toLowerCase();
+        const cityFiltered = matches.filter((r) => r.city && r.city.toLowerCase() === cityQ);
+        if (cityFiltered.length > 0) matches = cityFiltered;
+      }
+      if (matches.length === 0) {
+        return { content: [{ type: "text", text: "No restaurant found matching that name." }] };
+      }
+      const r = matches[0];
+      const reservationUrl = buildRefUrl(r.bookingUrl || r.website);
+      const platform = r.program === "chase" ? "opentable" : "resy";
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                name: r.name,
+                platform,
+                reservation_url: reservationUrl,
+                city: r.city,
+                state: r.state || null,
+              },
+              null,
+              2
+            ),
+          },
+        ],
+      };
+    }
+  );
+
+  return server;
+}
+
+// Vercel serverless handler
+export default async function handler(req, res) {
+  // Handle CORS
+  res.setHeader("Access-Control-Allow-Origin", "*");
+  res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
+  res.setHeader("Access-Control-Allow-Headers", "Content-Type, mcp-session-id");
+  res.setHeader("Access-Control-Expose-Headers", "mcp-session-id");
+
+  if (req.method === "OPTIONS") {
+    res.status(204).end();
+    return;
+  }
+
+  if (req.method === "GET") {
+    // Info endpoint
+    res.status(200).json({
+      name: "ReserveMap MCP Server",
+      description:
+        "Find restaurants where you can use premium credit card dining benefits (Chase Sapphire Reserve, Amex Global Dining Access). Get dining credits even as walk-ins.",
+      version: "1.0.0",
+      protocol: "streamable-http",
+    });
+    return;
+  }
+
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  try {
+    const server = createServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined, // Stateless mode for serverless
+    });
+    await server.connect(transport);
+    await transport.handleRequest(req, res, req.body);
+  } catch (err) {
+    console.error("MCP error:", err);
+    if (!res.headersSent) {
+      res.status(500).json({ error: "Internal server error" });
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -20,6 +20,24 @@
 
     <!-- Theme color for mobile browsers -->
     <meta name="theme-color" content="#0f172a" />
+
+    <!-- Structured Data for AI & Search Engines -->
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebApplication",
+      "name": "ReserveMap",
+      "description": "Find restaurants where you can use Chase Sapphire Reserve, Amex Global Dining Access, and other premium credit card dining benefits. Interactive map across 50+ US cities.",
+      "url": "https://reservemap.vercel.app",
+      "applicationCategory": "LifestyleApplication",
+      "operatingSystem": "Web",
+      "offers": {
+        "@type": "Offer",
+        "price": "0",
+        "priceCurrency": "USD"
+      }
+    }
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,16 @@
       "name": "reservemap",
       "version": "0.0.1",
       "dependencies": {
+        "@mcp-b/global": "^2.2.0",
+        "@mcp-b/react-webmcp": "^2.2.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
         "leaflet": "^1.9.4",
         "leaflet.markercluster": "^1.5.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-leaflet": "^4.2.1",
-        "react-router-dom": "^7.13.0"
+        "react-router-dom": "^7.13.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@types/react": "^18.2.0",
@@ -319,6 +323,12 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@cfworker/json-schema": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.1.1.tgz",
+      "integrity": "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==",
+      "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -711,6 +721,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -759,6 +781,151 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mcp-b/global": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/global/-/global-2.2.0.tgz",
+      "integrity": "sha512-3+FNuVXPGyhzYsVPL5UItMkTF+GD6E3iHEmuJY0yydjjpWtlqrUw7b7PLhyuymKcc1+jTMunyrr3Zps0uPEfiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/transports": "2.2.0",
+        "@mcp-b/webmcp-polyfill": "2.2.0",
+        "@mcp-b/webmcp-ts-sdk": "2.2.0",
+        "@mcp-b/webmcp-types": "2.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/react-webmcp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/react-webmcp/-/react-webmcp-2.2.0.tgz",
+      "integrity": "sha512-D2k/ZMGWfEd2pt4yBp2CgdAahBXRwcafFikSO6aSa2gc1CiPEL0A2aGMm0qEGF3REC5lY0yvybWWZJcqfdiPSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/global": "2.2.0",
+        "@mcp-b/transports": "2.2.0",
+        "@mcp-b/webmcp-polyfill": "2.2.0",
+        "@mcp-b/webmcp-ts-sdk": "2.2.0",
+        "@mcp-b/webmcp-types": "2.2.0"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mcp-b/transports": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/transports/-/transports-2.2.0.tgz",
+      "integrity": "sha512-zSqYekrmou72z67GF5jXaDnQdhT84Hlmi4meshm0zMn71GlaYmHhXfb3UsgW3xQ7Y5CexQ4U9L9IrdG6/+MTfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/webmcp-ts-sdk": "2.2.0",
+        "zod": "3.25.76"
+      }
+    },
+    "node_modules/@mcp-b/transports/node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-polyfill": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-polyfill/-/webmcp-polyfill-2.2.0.tgz",
+      "integrity": "sha512-as49JP4MHXVMMVNzD8938EsiU2tEzWNk7Un6c6C/xK5rstkIrQZQsVLbH7NFtmgMb6bbryzSqg9JWSFIxkU27Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "@mcp-b/webmcp-types": "2.2.0",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mcp-b/webmcp-ts-sdk": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-ts-sdk/-/webmcp-ts-sdk-2.2.0.tgz",
+      "integrity": "sha512-IzjwqrpbbASbAJxpr5k5m1ryiELGdnohDXzpLuB7UK2VI1rsAwQ04j59uRkMvaqZ4iwvxHTzKk+AajRB57OcPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@mcp-b/webmcp-polyfill": "2.2.0",
+        "@mcp-b/webmcp-types": "2.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        },
+        "zod-to-json-schema": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mcp-b/webmcp-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@mcp-b/webmcp-types/-/webmcp-types-2.2.0.tgz",
+      "integrity": "sha512-1/UYAwQKBkqRgK18GkbGR4m6Cn9vz6Qy6pTL5LIIinUOhR5dMLaNl/blH/tJT+nJleMmgDoFZWGAmmr+fAz2PQ==",
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1167,6 +1334,12 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1268,6 +1441,52 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1356,6 +1575,30 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1401,6 +1644,44 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/camelcase-css": {
@@ -1482,6 +1763,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1500,6 +1803,46 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/cssesc": {
@@ -1526,7 +1869,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1538,6 +1880,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/didyoumean": {
@@ -1554,12 +1905,71 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.279",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
       "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.21.5",
@@ -1610,6 +2020,118 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/express/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
     "node_modules/fast-glob": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
@@ -1640,6 +2162,22 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -1663,6 +2201,36 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "5.3.4",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
@@ -1675,6 +2243,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -1696,7 +2273,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1712,6 +2288,43 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -1725,17 +2338,109 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
+      "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-binary-path": {
@@ -1800,6 +2505,18 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -1808,6 +2525,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {
@@ -1828,6 +2554,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -1899,6 +2637,36 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -1923,11 +2691,35 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -1961,6 +2753,15 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
@@ -1982,7 +2783,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -1998,12 +2798,73 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.0.tgz",
+      "integrity": "sha512-PuseHIvAnz3bjrM2rGJtSgo1zjgxapTLZ7x2pjhzWwlp4SJQgK3f3iZIQwkpEnBaKz6seKBADpM4B4ySkuYypg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -2043,6 +2904,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -2208,6 +3078,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -2228,6 +3126,30 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -2339,6 +3261,15 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -2416,6 +3347,22 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -2440,6 +3387,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -2459,11 +3412,155 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/source-map-js": {
       "version": "1.2.1",
@@ -2473,6 +3570,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/sucrase": {
@@ -2633,12 +3739,44 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true,
       "license": "Apache-2.0"
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -2677,6 +3815,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",
@@ -2738,12 +3885,51 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,12 +9,16 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mcp-b/global": "^2.2.0",
+    "@mcp-b/react-webmcp": "^2.2.0",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "leaflet": "^1.9.4",
     "leaflet.markercluster": "^1.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-leaflet": "^4.2.1",
-    "react-router-dom": "^7.13.0"
+    "react-router-dom": "^7.13.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/public/.well-known/webmcp.json
+++ b/public/.well-known/webmcp.json
@@ -1,0 +1,39 @@
+{
+  "name": "ReserveMap",
+  "description": "Find restaurants where you can use premium credit card dining benefits. Covers Chase Sapphire Reserve, Amex Global Dining Access, Visa Dining Collection, and Dorsia.",
+  "tools": [
+    {
+      "name": "search_restaurants",
+      "description": "Search restaurants by name, city, program, or cuisine"
+    },
+    {
+      "name": "get_restaurant_details",
+      "description": "Get full details for a specific restaurant including dining programs and reservation links"
+    },
+    {
+      "name": "get_restaurants_near_location",
+      "description": "Find participating restaurants near a geographic location"
+    },
+    {
+      "name": "list_programs",
+      "description": "List all supported credit card dining programs"
+    },
+    {
+      "name": "get_program_cities",
+      "description": "List all cities that have restaurants for a given program"
+    },
+    {
+      "name": "navigate_to_restaurant",
+      "description": "Pan the map to a specific restaurant and open its detail view"
+    },
+    {
+      "name": "filter_map_by_program",
+      "description": "Filter the map to show only restaurants from a specific program"
+    },
+    {
+      "name": "open_reservation",
+      "description": "Get a reservation link for a restaurant on OpenTable or Resy"
+    }
+  ],
+  "mcp_endpoint": "/mcp"
+}

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,25 @@
+# ReserveMap
+> All your dining benefits. One map.
+
+ReserveMap consolidates premium credit card dining benefits into a single searchable map.
+
+## Supported Programs
+- Chase Sapphire Reserve (via OpenTable) — ~2,400 restaurants across 50+ US cities
+- Amex Global Dining Access (via Resy) — ~7,000+ restaurants across the US
+- Visa Dining Collection (via OpenTable)
+- Dorsia
+
+## How It Works
+Many premium credit cards offer dining credits ($50-100+) at participating restaurants.
+These credits often work even as walk-ins — no advance reservation required.
+ReserveMap shows you where to use them on a map so you can plan around proximity.
+
+## MCP Server
+Connect to ReserveMap's data via MCP (Model Context Protocol) at the /mcp endpoint.
+
+## API
+Use the MCP server for programmatic access to restaurant data.
+
+## Links
+- Website: https://reservemap.vercel.app
+- Source: https://github.com/cdsmith16/reservemap

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,17 @@
+User-agent: *
+Allow: /
+
+# AI Agent Discovery
+User-agent: GPTBot
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: Googlebot
+Allow: /
+
+Sitemap: https://reservemap.vercel.app/sitemap.xml

--- a/src/components/Map.jsx
+++ b/src/components/Map.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react'
 import L from 'leaflet'
 import personPinUrl from './icons/person_pin_blue_cyan.svg'
+import { buildReservationUrl } from '../utils/reservationUrl'
 import 'leaflet/dist/leaflet.css'
 import 'leaflet.markercluster/dist/MarkerCluster.css'
 import 'leaflet.markercluster/dist/MarkerCluster.Default.css'
@@ -269,7 +270,7 @@ export default function Map({ restaurants, filters, flyToLocation, onFlyComplete
 function createPopupContent(restaurant) {
   const isAmex = restaurant.program === 'amex'
 
-  const bookingUrl = restaurant.bookingUrl || ''
+  const bookingUrl = buildReservationUrl(restaurant.bookingUrl) || ''
   const websiteUrl = restaurant.website || ''
   const buttonUrl = bookingUrl || websiteUrl
   const bookingBg = isAmex ? '#fbbf24' : '#dc2626'

--- a/src/hooks/useReserveMapWebMCP.js
+++ b/src/hooks/useReserveMapWebMCP.js
@@ -1,0 +1,322 @@
+import { useEffect } from 'react';
+import '@mcp-b/global';
+import { buildReservationUrl } from '../utils/reservationUrl';
+
+function haversineDistance(lat1, lon1, lat2, lon2) {
+  const R = 3959;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLon = ((lon2 - lon1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLon / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+const PROGRAMS = [
+  {
+    id: 'chase_sapphire',
+    name: 'Chase Sapphire Reserve',
+    description: 'Premium dining benefits through OpenTable partnership',
+    card_required: 'Chase Sapphire Reserve',
+    benefit_description: 'Dining credits at participating OpenTable restaurants. Credits work even as walk-ins.',
+    dataKey: 'chase',
+  },
+  {
+    id: 'amex_gda',
+    name: 'Amex Global Dining Access',
+    description: 'Global Dining Access by Resy for Amex Platinum/Centurion cardholders',
+    card_required: 'Amex Platinum / Centurion',
+    benefit_description: 'Dining credits at participating Resy restaurants. Credits work even as walk-ins.',
+    dataKey: 'amex',
+  },
+];
+
+function programIdToDataKey(id) {
+  const p = PROGRAMS.find((p) => p.id === id);
+  return p ? p.dataKey : id;
+}
+
+function formatRestaurant(r) {
+  return {
+    name: r.name,
+    program: r.program === 'chase' ? 'chase_sapphire' : 'amex_gda',
+    city: r.city || null,
+    state: r.state || null,
+    address: r.address || null,
+    cuisine: r.cuisine || null,
+    neighborhood: r.neighborhood || null,
+    website: r.website || null,
+    reservation_url: buildReservationUrl(r.bookingUrl),
+    coordinates: { lat: r.lat, lon: r.lon },
+  };
+}
+
+export function useReserveMapWebMCP({ restaurants, mapRef, filters, setFilters, setFlyToLocation }) {
+  useEffect(() => {
+    if (!('modelContext' in navigator)) return;
+
+    const registrations = [];
+
+    // 1. search_restaurants
+    registrations.push(
+      navigator.modelContext.registerTool({
+        name: 'search_restaurants',
+        description:
+          'Search ReserveMap restaurants by name, city, state, cuisine, or dining program. Returns restaurants where you can use Chase Sapphire Reserve or Amex Global Dining Access credits. These credits work even as walk-ins without advance reservations.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            query: { type: 'string', description: 'Search term (restaurant name, cuisine, neighborhood)' },
+            program: {
+              type: 'string',
+              enum: ['chase_sapphire', 'amex_gda'],
+              description: 'Filter by credit card dining program',
+            },
+            city: { type: 'string', description: 'Filter by city name' },
+            state: { type: 'string', description: 'Filter by US state (2-letter code)' },
+            limit: { type: 'number', description: 'Max results to return (default 20)' },
+          },
+        },
+        async execute(args) {
+          let results = [...restaurants];
+          if (args.query) {
+            const q = args.query.toLowerCase();
+            results = results.filter(
+              (r) =>
+                r.name.toLowerCase().includes(q) ||
+                (r.city && r.city.toLowerCase().includes(q)) ||
+                (r.cuisine && r.cuisine.toLowerCase().includes(q)) ||
+                (r.neighborhood && r.neighborhood.toLowerCase().includes(q))
+            );
+          }
+          if (args.program) {
+            const dataKey = programIdToDataKey(args.program);
+            results = results.filter((r) => r.program === dataKey);
+          }
+          if (args.city) results = results.filter((r) => r.city && r.city.toLowerCase() === args.city.toLowerCase());
+          if (args.state) results = results.filter((r) => r.state && r.state.toLowerCase() === args.state.toLowerCase());
+          const limited = results.slice(0, args.limit || 20);
+          return { content: [{ type: 'text', text: JSON.stringify(limited.map(formatRestaurant)) }] };
+        },
+      })
+    );
+
+    // 2. get_restaurant_details
+    registrations.push(
+      navigator.modelContext.registerTool({
+        name: 'get_restaurant_details',
+        description:
+          'Get full details for a specific restaurant including all dining programs it participates in, address, coordinates, website, and reservation links.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Restaurant name to look up' },
+            city: { type: 'string', description: 'City to disambiguate if multiple matches' },
+          },
+          required: ['name'],
+        },
+        async execute(args) {
+          const q = args.name.toLowerCase();
+          let matches = restaurants.filter((r) => r.name.toLowerCase().includes(q));
+          if (args.city) {
+            const cityQ = args.city.toLowerCase();
+            const cityFiltered = matches.filter((r) => r.city && r.city.toLowerCase() === cityQ);
+            if (cityFiltered.length > 0) matches = cityFiltered;
+          }
+          if (matches.length === 0) return { content: [{ type: 'text', text: 'No restaurant found.' }] };
+          return { content: [{ type: 'text', text: JSON.stringify(matches.slice(0, 5).map(formatRestaurant)) }] };
+        },
+      })
+    );
+
+    // 3. list_programs
+    registrations.push(
+      navigator.modelContext.registerTool({
+        name: 'list_programs',
+        description: 'List all available premium credit card dining programs with descriptions and restaurant counts.',
+        inputSchema: { type: 'object', properties: {} },
+        async execute() {
+          const programsWithCounts = PROGRAMS.map((p) => ({
+            id: p.id,
+            name: p.name,
+            description: p.description,
+            card_required: p.card_required,
+            benefit_description: p.benefit_description,
+            restaurant_count: restaurants.filter((r) => r.program === p.dataKey).length,
+          }));
+          return { content: [{ type: 'text', text: JSON.stringify(programsWithCounts) }] };
+        },
+      })
+    );
+
+    // 4. get_restaurants_near_location
+    registrations.push(
+      navigator.modelContext.registerTool({
+        name: 'get_restaurants_near_location',
+        description:
+          'Find restaurants near a lat/lon point. Returns results sorted by distance. Useful for finding nearby dining credit opportunities.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            lat: { type: 'number', description: 'Latitude' },
+            lon: { type: 'number', description: 'Longitude' },
+            radius_miles: { type: 'number', description: 'Search radius in miles (default 5)' },
+            program: { type: 'string', enum: ['chase_sapphire', 'amex_gda'], description: 'Filter by program' },
+            limit: { type: 'number', description: 'Max results (default 20)' },
+          },
+          required: ['lat', 'lon'],
+        },
+        async execute(args) {
+          const radius = args.radius_miles || 5;
+          let candidates = [...restaurants];
+          if (args.program) {
+            const dataKey = programIdToDataKey(args.program);
+            candidates = candidates.filter((r) => r.program === dataKey);
+          }
+          const withDistance = candidates
+            .map((r) => ({ ...r, distance_miles: haversineDistance(args.lat, args.lon, r.lat, r.lon) }))
+            .filter((r) => r.distance_miles <= radius)
+            .sort((a, b) => a.distance_miles - b.distance_miles)
+            .slice(0, args.limit || 20);
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify(
+                  withDistance.map((r) => ({
+                    ...formatRestaurant(r),
+                    distance_miles: Math.round(r.distance_miles * 100) / 100,
+                  }))
+                ),
+              },
+            ],
+          };
+        },
+      })
+    );
+
+    // 5. get_program_cities
+    registrations.push(
+      navigator.modelContext.registerTool({
+        name: 'get_program_cities',
+        description: 'List all cities that have restaurants for a given program, with counts.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            program: { type: 'string', enum: ['chase_sapphire', 'amex_gda'], description: 'Program to list cities for' },
+          },
+          required: ['program'],
+        },
+        async execute(args) {
+          const dataKey = programIdToDataKey(args.program);
+          const programRestaurants = restaurants.filter((r) => r.program === dataKey);
+          const cityMap = {};
+          for (const r of programRestaurants) {
+            if (!r.city) continue;
+            const key = `${r.city}|${r.state || ''}`;
+            if (!cityMap[key]) cityMap[key] = { city: r.city, state: r.state || null, count: 0 };
+            cityMap[key].count++;
+          }
+          const cities = Object.values(cityMap).sort((a, b) => b.count - a.count);
+          return { content: [{ type: 'text', text: JSON.stringify(cities) }] };
+        },
+      })
+    );
+
+    // 6. navigate_to_restaurant (destructive — changes visible page)
+    registrations.push(
+      navigator.modelContext.registerTool({
+        name: 'navigate_to_restaurant',
+        description: 'Pan the map to a specific restaurant and open its popup/detail view. Changes the visible map state.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Restaurant name' },
+            city: { type: 'string', description: 'City to disambiguate' },
+          },
+          required: ['name'],
+        },
+        annotations: { destructive: true },
+        async execute(args) {
+          const q = args.name.toLowerCase();
+          let matches = restaurants.filter((r) => r.name.toLowerCase().includes(q));
+          if (args.city) {
+            const cityQ = args.city.toLowerCase();
+            const cityFiltered = matches.filter((r) => r.city && r.city.toLowerCase() === cityQ);
+            if (cityFiltered.length > 0) matches = cityFiltered;
+          }
+          if (matches.length === 0) return { content: [{ type: 'text', text: 'No restaurant found.' }] };
+          const r = matches[0];
+          setFlyToLocation({ lat: r.lat, lon: r.lon, zoom: 16 });
+          return { content: [{ type: 'text', text: JSON.stringify({ navigated: true, ...formatRestaurant(r) }) }] };
+        },
+      })
+    );
+
+    // 7. filter_map_by_program (destructive — changes visible markers)
+    registrations.push(
+      navigator.modelContext.registerTool({
+        name: 'filter_map_by_program',
+        description: 'Apply a program filter to the map view. Shows only restaurants from the selected program.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            program: {
+              type: 'string',
+              enum: ['chase_sapphire', 'amex_gda', 'all'],
+              description: 'Program to filter by, or "all" to show everything',
+            },
+          },
+          required: ['program'],
+        },
+        annotations: { destructive: true },
+        async execute(args) {
+          const newFilters =
+            args.program === 'all'
+              ? { amex: true, chase: true }
+              : { amex: args.program === 'amex_gda', chase: args.program === 'chase_sapphire' };
+          setFilters(newFilters);
+          const count = restaurants.filter(
+            (r) => (r.program === 'amex' && newFilters.amex) || (r.program === 'chase' && newFilters.chase)
+          ).length;
+          return { content: [{ type: 'text', text: JSON.stringify({ program: args.program, visible_restaurants: count }) }] };
+        },
+      })
+    );
+
+    // 8. open_reservation (action)
+    registrations.push(
+      navigator.modelContext.registerTool({
+        name: 'open_reservation',
+        description:
+          'Open a reservation link for a restaurant on OpenTable or Resy in a new tab. Appends referral tracking.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', description: 'Restaurant name' },
+            city: { type: 'string', description: 'City to disambiguate' },
+          },
+          required: ['name'],
+        },
+        async execute(args) {
+          const q = args.name.toLowerCase();
+          let matches = restaurants.filter((r) => r.name.toLowerCase().includes(q));
+          if (args.city) {
+            const cityQ = args.city.toLowerCase();
+            const cityFiltered = matches.filter((r) => r.city && r.city.toLowerCase() === cityQ);
+            if (cityFiltered.length > 0) matches = cityFiltered;
+          }
+          if (matches.length === 0) return { content: [{ type: 'text', text: 'No restaurant found.' }] };
+          const r = matches[0];
+          const url = buildReservationUrl(r.bookingUrl || r.website);
+          if (url) window.open(url, '_blank');
+          return { content: [{ type: 'text', text: JSON.stringify({ name: r.name, reservation_url: url }) }] };
+        },
+      })
+    );
+
+    return () => registrations.forEach((r) => r.unregister());
+  }, [restaurants, mapRef, filters, setFilters, setFlyToLocation]);
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useMemo } from 'react'
 import Map from '../components/Map'
 import DiningBenefits from '../components/DiningBenefits'
+import { useReserveMapWebMCP } from '../hooks/useReserveMapWebMCP'
 
 export default function Home() {
   const [restaurants, setRestaurants] = useState([])
@@ -14,6 +15,10 @@ export default function Home() {
   const [flyToLocation, setFlyToLocation] = useState(null)
   const searchRef = useRef(null)
   const mapSectionRef = useRef(null)
+  const mapRef = useRef(null)
+
+  // Register WebMCP tools for browser-based AI agents
+  useReserveMapWebMCP({ restaurants, mapRef, filters, setFilters, setFlyToLocation })
 
   // Load restaurant data
   useEffect(() => {

--- a/src/utils/reservationUrl.js
+++ b/src/utils/reservationUrl.js
@@ -1,0 +1,10 @@
+export function buildReservationUrl(baseUrl) {
+  if (!baseUrl) return null;
+  try {
+    const url = new URL(baseUrl);
+    url.searchParams.set('ref', 'ReserveMap');
+    return url.toString();
+  } catch {
+    return baseUrl;
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,9 +2,35 @@
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "rewrites": [
+    { "source": "/.well-known/webmcp.json", "destination": "/.well-known/webmcp.json" },
+    { "source": "/llms.txt", "destination": "/llms.txt" },
+    { "source": "/robots.txt", "destination": "/robots.txt" },
+    { "source": "/api/mcp", "destination": "/api/mcp" },
+    { "source": "/(.*)", "destination": "/index.html" }
+  ],
+  "headers": [
     {
-      "source": "/(.*)",
-      "destination": "/index.html"
+      "source": "/.well-known/webmcp.json",
+      "headers": [
+        { "key": "Content-Type", "value": "application/json" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    },
+    {
+      "source": "/llms.txt",
+      "headers": [
+        { "key": "Content-Type", "value": "text/plain" },
+        { "key": "Access-Control-Allow-Origin", "value": "*" }
+      ]
+    },
+    {
+      "source": "/api/mcp",
+      "headers": [
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, DELETE, OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type, mcp-session-id" },
+        { "key": "Access-Control-Expose-Headers", "value": "mcp-session-id" }
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Track 1 (WebMCP): Register 8 client-side tools via navigator.modelContext
  for browser-based AI agents (search, navigate, filter, reserve)
- Track 2 (Backend MCP): Vercel serverless function at /api/mcp exposing
  the same tools via Streamable HTTP for Claude Desktop, ChatGPT, etc.
- Track 3 (Discoverability): robots.txt, llms.txt, .well-known/webmcp.json,
  JSON-LD structured data in index.html
- Track 4 (Referrals): buildReservationUrl utility appends ?ref=ReserveMap
  to all outbound booking links
- Track 5 (Vercel config): Updated rewrites and CORS headers for new endpoints

https://claude.ai/code/session_0193TDbQRav7Yap5FupdyRgh